### PR TITLE
Add specific folder per python version

### DIFF
--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3.6.12-buster
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -y install graphviz graphviz-dev


### PR DESCRIPTION
First step: add a specific folder for 3.6 (with a pinned version).

Then:
* Change the setup on dockerhub
* Remove the root dockerfile on this project (next PR)
* Add some additional python versions (final PRs)